### PR TITLE
Populate AP end_access_unit of buffer. Handle FU.serialize arg rest > 3

### DIFF
--- a/lib/nal_formats/fu.ex
+++ b/lib/nal_formats/fu.ex
@@ -43,43 +43,50 @@ defmodule Membrane.RTP.H265.FU do
   Serialize H265 unit into list of FU payloads
   """
   @spec serialize(binary(), pos_integer()) :: list(binary()) | {:error, :unit_too_small}
-  def serialize(data, preferred_size) do
-    case data do
-      <<header::2-binary, head::binary-size(preferred_size), rest::binary>> ->
-        <<r::1, type::6, layer_id::6, t_id::3>> = header
+  def serialize(<<header::2-binary, rest::binary>>, preferred_size) when byte_size(rest) >= 2 do
+    <<r::1, type::6, layer_id::6, t_id::3>> = header
 
-        payload =
-          head
-          |> FU.Header.add_header(1, 0, type)
-          |> NAL.Header.add_header(r, NAL.Header.encode_type(:fu), layer_id, t_id)
+    # An FU must consist of at least a start and an end fragment. The first
+    # chunk is capped at byte_size(rest) - 1 so a unit barely exceeding
+    # preferred_size still leaves data for the end fragment (upstream matched
+    # exactly preferred_size, so units of preferred_size + 3 bytes returned
+    # {:error, :unit_too_small} and units of preferred_size + 4 bytes emitted
+    # a start fragment with no end fragment).
+    chunk_size = min(preferred_size, byte_size(rest) - 1)
+    <<head::binary-size(chunk_size), rest::binary>> = rest
 
-        [payload | do_serialize(rest, r, type, layer_id, t_id, preferred_size)]
+    payload =
+      head
+      |> FU.Header.add_header(1, 0, type)
+      |> NAL.Header.add_header(r, NAL.Header.encode_type(:fu), layer_id, t_id)
 
-      _data ->
-        {:error, :unit_too_small}
-    end
+    [payload | do_serialize(rest, r, type, layer_id, t_id, preferred_size)]
   end
 
-  defp do_serialize(data, r, type, layer_id, t_id, preferred_size) do
-    case data do
-      <<head::binary-size(preferred_size), rest::binary>> ->
-        payload =
-          head
-          |> FU.Header.add_header(0, 0, type)
-          |> NAL.Header.add_header(r, NAL.Header.encode_type(:fu), layer_id, t_id)
+  def serialize(_data, _preferred_size), do: {:error, :unit_too_small}
 
-        [payload] ++ do_serialize(rest, r, type, layer_id, t_id, preferred_size)
+  # The strict inequality keeps a remainder that is an exact multiple of
+  # preferred_size from recursing into <<>> — the final chunk must always go
+  # through the end-fragment clause below (upstream emitted its last fragment
+  # with end_bit 0 in that case, so the receiver could never complete the FU).
+  defp do_serialize(data, r, type, layer_id, t_id, preferred_size)
+       when byte_size(data) > preferred_size do
+    <<head::binary-size(preferred_size), rest::binary>> = data
 
-      <<>> ->
-        []
+    payload =
+      head
+      |> FU.Header.add_header(0, 0, type)
+      |> NAL.Header.add_header(r, NAL.Header.encode_type(:fu), layer_id, t_id)
 
-      rest ->
-        [
-          rest
-          |> FU.Header.add_header(0, 1, type)
-          |> NAL.Header.add_header(r, NAL.Header.encode_type(:fu), layer_id, t_id)
-        ]
-    end
+    [payload | do_serialize(rest, r, type, layer_id, t_id, preferred_size)]
+  end
+
+  defp do_serialize(data, r, type, layer_id, t_id, _preferred_size) do
+    [
+      data
+      |> FU.Header.add_header(0, 1, type)
+      |> NAL.Header.add_header(r, NAL.Header.encode_type(:fu), layer_id, t_id)
+    ]
   end
 
   defp do_parse(header, data, seq_num, acc)

--- a/lib/nal_formats/fu.ex
+++ b/lib/nal_formats/fu.ex
@@ -65,10 +65,6 @@ defmodule Membrane.RTP.H265.FU do
 
   def serialize(_data, _preferred_size), do: {:error, :unit_too_small}
 
-  # The strict inequality keeps a remainder that is an exact multiple of
-  # preferred_size from recursing into <<>> — the final chunk must always go
-  # through the end-fragment clause below (upstream emitted its last fragment
-  # with end_bit 0 in that case, so the receiver could never complete the FU).
   defp do_serialize(data, r, type, layer_id, t_id, preferred_size)
        when byte_size(data) > preferred_size do
     <<head::binary-size(preferred_size), rest::binary>> = data

--- a/lib/payloader.ex
+++ b/lib/payloader.ex
@@ -52,6 +52,7 @@ defmodule Membrane.RTP.H265.Payloader do
         pts: 0,
         dts: 0,
         metadata: nil,
+        end_access_unit: false,
         layer_id: 0,
         tid: 1,
         reserved: 0
@@ -121,6 +122,8 @@ defmodule Membrane.RTP.H265.Payloader do
         | payloads: [buffer.payload | ap_acc.payloads],
           byte_size: size,
           metadata: ap_acc.metadata || buffer.metadata,
+          end_access_unit:
+            ap_acc.end_access_unit or Map.get(buffer.metadata.h265, :end_access_unit, false),
           pts: buffer.pts,
           dts: buffer.dts,
           reserved: max(ap_acc.reserved, r),
@@ -135,6 +138,11 @@ defmodule Membrane.RTP.H265.Payloader do
     end
   end
 
+  # The marker must come from the accumulated end_access_unit flag, not from
+  # `ap_acc.metadata` — that holds the FIRST aggregated NALU's metadata (e.g. a
+  # prefix SEI), so an AP that carries a whole small access unit (SEI + slice)
+  # would never get the marker and strict receivers (WebKit) never complete the
+  # frame.
   defp flush_stap_acc(%{ap_acc: ap_acc} = state) do
     buffers =
       case ap_acc.payloads do
@@ -143,31 +151,24 @@ defmodule Membrane.RTP.H265.Payloader do
 
         [payload] ->
           # use single nalu
-          [
-            %Buffer{
-              payload: payload,
-              metadata: ap_acc.metadata,
-              pts: ap_acc.pts,
-              dts: ap_acc.dts
-            }
-            |> set_marker()
-          ]
+          [ap_buffer(payload, ap_acc)]
 
         payloads ->
           payload = AP.serialize(payloads, ap_acc.reserved, ap_acc.layer_id, ap_acc.tid)
-
-          [
-            %Buffer{
-              payload: payload,
-              metadata: ap_acc.metadata,
-              pts: ap_acc.pts,
-              dts: ap_acc.dts
-            }
-            |> set_marker()
-          ]
+          [ap_buffer(payload, ap_acc)]
       end
 
     {buffers, %{state | ap_acc: %State{}.ap_acc}}
+  end
+
+  defp ap_buffer(payload, ap_acc) do
+    %Buffer{
+      payload: payload,
+      metadata: ap_acc.metadata,
+      pts: ap_acc.pts,
+      dts: ap_acc.dts
+    }
+    |> Bunch.Struct.put_in([:metadata, :rtp], %{marker: ap_acc.end_access_unit})
   end
 
   defp try_single_nalu(buffer, state) do

--- a/lib/payloader.ex
+++ b/lib/payloader.ex
@@ -52,7 +52,6 @@ defmodule Membrane.RTP.H265.Payloader do
         pts: 0,
         dts: 0,
         metadata: nil,
-        end_access_unit: false,
         layer_id: 0,
         tid: 1,
         reserved: 0
@@ -121,9 +120,7 @@ defmodule Membrane.RTP.H265.Payloader do
         ap_acc
         | payloads: [buffer.payload | ap_acc.payloads],
           byte_size: size,
-          metadata: ap_acc.metadata || buffer.metadata,
-          end_access_unit:
-            ap_acc.end_access_unit or Map.get(buffer.metadata.h265, :end_access_unit, false),
+          metadata: buffer.metadata,
           pts: buffer.pts,
           dts: buffer.dts,
           reserved: max(ap_acc.reserved, r),
@@ -138,11 +135,6 @@ defmodule Membrane.RTP.H265.Payloader do
     end
   end
 
-  # The marker must come from the accumulated end_access_unit flag, not from
-  # `ap_acc.metadata` — that holds the FIRST aggregated NALU's metadata (e.g. a
-  # prefix SEI), so an AP that carries a whole small access unit (SEI + slice)
-  # would never get the marker and strict receivers (WebKit) never complete the
-  # frame.
   defp flush_stap_acc(%{ap_acc: ap_acc} = state) do
     buffers =
       case ap_acc.payloads do
@@ -168,7 +160,9 @@ defmodule Membrane.RTP.H265.Payloader do
       pts: ap_acc.pts,
       dts: ap_acc.dts
     }
-    |> Bunch.Struct.put_in([:metadata, :rtp], %{marker: ap_acc.end_access_unit})
+    |> Bunch.Struct.put_in([:metadata, :rtp], %{
+      marker: Map.get(ap_acc.metadata.h265, :end_access_unit, false)
+    })
   end
 
   defp try_single_nalu(buffer, state) do

--- a/test/nal_formatters/fu_test.exs
+++ b/test/nal_formatters/fu_test.exs
@@ -4,10 +4,11 @@ defmodule Membrane.RTP.H265.FUTest do
   use ExUnit.Case
   use Bunch
 
-  alias Membrane.RTP.H265.FU
+  alias Membrane.RTP.H265.{FU, NAL}
   alias Membrane.Support.Formatters.FUFactory
 
   @base_seq_num 4567
+  @nal_header <<0::1, 1::6, 0::6, 1::3>>
 
   describe "Fragmentation Unit parser" do
     test "parses first packet" do
@@ -70,5 +71,95 @@ defmodule Membrane.RTP.H265.FUTest do
     test "returns error when header is not valid" do
       assert {:error, :packet_malformed} == FU.parse(<<0::2, 1::5>>, 0, %FU{})
     end
+  end
+
+  describe "serialize/2" do
+    test "returns error when there isn't enough data left for a start and an end fragment" do
+      assert FU.serialize(unit(0), 4) == {:error, :unit_too_small}
+      assert FU.serialize(unit(1), 4) == {:error, :unit_too_small}
+    end
+
+    test "always produces a start and an end fragment, even for the smallest valid unit" do
+      fragments = FU.serialize(unit(2), 4)
+
+      assert [start_fragment, end_fragment] = fragments
+
+      assert {_nal, %FU.Header{start_bit: true, end_bit: false}, _data} =
+               decode_fragment(start_fragment)
+
+      assert {_nal, %FU.Header{start_bit: false, end_bit: true}, _data} =
+               decode_fragment(end_fragment)
+    end
+
+    test "keeps an end fragment when the payload exactly matches preferred_size" do
+      fragments = FU.serialize(unit(4), 4)
+
+      assert [start_fragment, end_fragment] = fragments
+
+      assert {_nal, %FU.Header{start_bit: true, end_bit: false}, start_data} =
+               decode_fragment(start_fragment)
+
+      assert {_nal, %FU.Header{start_bit: false, end_bit: true}, end_data} =
+               decode_fragment(end_fragment)
+
+      assert byte_size(start_data) + byte_size(end_data) == 4
+      assert byte_size(end_data) > 0
+    end
+
+    test "does not emit an empty trailing fragment when the payload is an exact multiple of preferred_size" do
+      fragments = FU.serialize(unit(8), 4)
+
+      assert [start_fragment, end_fragment] = fragments
+
+      assert {_nal, %FU.Header{start_bit: true, end_bit: false}, start_data} =
+               decode_fragment(start_fragment)
+
+      assert {_nal, %FU.Header{start_bit: false, end_bit: true}, end_data} =
+               decode_fragment(end_fragment)
+
+      assert byte_size(start_data) == 4
+      assert byte_size(end_data) == 4
+    end
+
+    test "splits a payload spanning more than two chunks into start, middle and end fragments" do
+      fragments = FU.serialize(unit(9), 4)
+
+      assert [start_fragment, middle_fragment, end_fragment] = fragments
+
+      assert {_nal, %FU.Header{start_bit: true, end_bit: false}, _} =
+               decode_fragment(start_fragment)
+
+      assert {_nal, %FU.Header{start_bit: false, end_bit: false}, middle_data} =
+               decode_fragment(middle_fragment)
+
+      assert {_nal, %FU.Header{start_bit: false, end_bit: true}, end_data} =
+               decode_fragment(end_fragment)
+
+      assert byte_size(middle_data) == 4
+      assert byte_size(end_data) == 1
+    end
+
+    test "reassembled fragment data equals the original payload" do
+      original = :binary.copy(<<1, 2, 3, 4>>, 3)
+      fragments = FU.serialize(@nal_header <> original, 4)
+
+      reassembled =
+        fragments
+        |> Enum.map(fn fragment ->
+          {_nal, _fu_header, data} = decode_fragment(fragment)
+          data
+        end)
+        |> Enum.join()
+
+      assert reassembled == original
+    end
+  end
+
+  defp unit(rest_size), do: @nal_header <> :binary.copy(<<1>>, rest_size)
+
+  defp decode_fragment(fragment) do
+    {:ok, {nal_header, rest}} = NAL.Header.parse_unit_header(fragment)
+    {:ok, {fu_header, data}} = FU.Header.parse(rest)
+    {nal_header, fu_header, data}
   end
 end

--- a/test/payloader_pipeline_test.exs
+++ b/test/payloader_pipeline_test.exs
@@ -84,6 +84,35 @@ defmodule Membrane.RTP.H265.PayloaderPipelineTest do
       Membrane.Pipeline.terminate(pid)
     end
 
+    test "AP marker reflects the last aggregated NALU's end_access_unit, not the first's" do
+      number_of_packets = 3
+      single_size = div(@max_size - 2, number_of_packets) - 2
+      single_unit = <<0::size(single_size)-unit(8)>>
+
+      buffers =
+        1..number_of_packets
+        |> Enum.map(fn i ->
+          %Buffer{
+            payload: <<1::32>> <> single_unit,
+            metadata: %{timestamp: 0, h265: %{end_access_unit: i == number_of_packets}}
+          }
+        end)
+
+      pid =
+        buffers
+        |> Source.output_from_buffers()
+        |> PayloaderTestingPipeline.start_pipeline()
+
+      assert_sink_buffer(pid, :sink, %Buffer{payload: data, metadata: metadata})
+      assert metadata.rtp.marker == true
+      type = NAL.Header.encode_type(:ap)
+      assert <<0::1, ^type::6, 0::6, 0::3, rest::binary>> = data
+      assert {:ok, glued} = AP.parse(rest)
+      assert Enum.map(glued, &elem(&1, 0)) == List.duplicate(single_unit, number_of_packets)
+
+      Membrane.Pipeline.terminate(pid)
+    end
+
     test "payloads single NAL units" do
       number_of_packets = 16
 


### PR DESCRIPTION
I am currently working on adding H265 into our WebRTC pipeline with RTP as ingress. After starting the video flow, a NAL of exactly max_payload_size + 3 total bytes returned {:error, :unit_too_small} → Protocol.UndefinedError; exact-multiple sizes emitted a start-FU with no end fragment, undecodable.
After `FU.serialize` fix, video started playing, but with 1 fps framerate. After some investigation, found out that Aggregation Packets must have enc_access_unit populated.
Let me know if this PR make sense :)